### PR TITLE
Fix/ci

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,6 @@
     "jsx": "react-jsx",
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.stories.tsx"]
 }


### PR DESCRIPTION
*.stories.tsx 코드들이 빌드할때 추가되면서, `devDependencies` 에 있는 `@storybook` 을 못 찾는 문제가 발생하여 CI가 안 돌고 있습니다. 이를 고치는 PR입니다.