### PR TITLE
Fix scroll issue on iOS Device (#56)

### DIFF
--- a/src/components/common/Scaffold/Scaffold.scss
+++ b/src/components/common/Scaffold/Scaffold.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   overflow: hidden;
   background: var(--background);
-  min-height: -webkit-fit-content;
+  min-height: fit-content;
   padding: 0px 100px;
   justify-content: center;
 }

--- a/src/components/common/Scaffold/Scaffold.scss
+++ b/src/components/common/Scaffold/Scaffold.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   overflow: hidden;
   background: var(--background);
-  min-height: -webkit-fill-available;
+  min-height: -webkit-fit-content;
   padding: 0px 100px;
   justify-content: center;
 }


### PR DESCRIPTION
# 재현 및 수정이 확인된 환경
- `iPad 7th gen (iOS 14.4.2)`
  - `Chrome 90.0.4430.216`
  - `Safari`

`Firefox Daylight 34.0 (4920)`에서는 해당 이슈가 재현되지 않았습니다.
 
# 개요

@ayaysir 께서 제시해주신 수정사항을 반영하여 local에서 테스트해본 결과 해당 문제가 수정되는 것으로 보입니다.

다만, https://caniuse.com/intrinsic-width 을 참조하여 vendor prefix가 없는 `fit-content`을 사용하였습니다.

# 스크린샷

Before
![IMG_0091](https://user-images.githubusercontent.com/19284878/120523606-0d350a00-c411-11eb-8be0-93d82e02388b.PNG)
![IMG_0092](https://user-images.githubusercontent.com/19284878/120523589-073f2900-c411-11eb-9006-adab39b4c280.PNG)

---

After
![IMG_0094](https://user-images.githubusercontent.com/19284878/120523883-68ff9300-c411-11eb-81b8-b7045591081f.PNG)
![IMG_0093](https://user-images.githubusercontent.com/19284878/120523890-6b61ed00-c411-11eb-9078-fbd134e7629c.PNG)
